### PR TITLE
Make building crypto_mb apps optional.

### DIFF
--- a/sources/ippcp/crypto_mb/src/CMakeLists.txt
+++ b/sources/ippcp/crypto_mb/src/CMakeLists.txt
@@ -104,4 +104,6 @@ else()
 endif()
 
 # Applications.
-add_subdirectory(apps)
+if(NOT DEFINED NO_APPS)
+    add_subdirectory(apps)
+endif()


### PR DESCRIPTION
In case NO_APPS is defined in CMake, build only the library.