### PR TITLE
BoringSSL compatibility fix.

### DIFF
--- a/sources/ippcp/crypto_mb/CMakeLists.txt
+++ b/sources/ippcp/crypto_mb/CMakeLists.txt
@@ -40,7 +40,13 @@ if(NOT OPENSSL_DISABLE)
         # Link static OpenSSL only for patched version
         set(OPENSSL_USE_STATIC_LIBS TRUE)
     endif()
-    find_package(OpenSSL 1.1.0 REQUIRED) # set -DOPENSSL_INCLUDE_DIR= -DOPENSSL_LIBRARIES= -DOPENSSL_ROOT_DIR= to use patched
+    if(BORINGSSL) # off by default
+        # BoringSSL doesn't appear to have version information found
+        # by find_package(OpenSSL)
+        find_package(OpenSSL REQUIRED)
+    else()
+        find_package(OpenSSL 1.1.0 REQUIRED) # set -DOPENSSL_INCLUDE_DIR= -DOPENSSL_LIBRARIES= -DOPENSSL_ROOT_DIR= to use patched
+    endif()
     list(APPEND MB_INCLUDE_DIRS "${OPENSSL_INCLUDE_DIR}")
 endif()
 

--- a/sources/ippcp/crypto_mb/src/common/ifma_cvt52.c
+++ b/sources/ippcp/crypto_mb/src/common/ifma_cvt52.c
@@ -167,6 +167,12 @@ __INLINE void transform_8sb_to_mb8(U64 out_mb8[], int bitLen, int8u *inp[8], int
    }
 }
 
+#ifdef OPENSSL_IS_BORINGSSL
+static int BN_bn2lebinpad(const BIGNUM *a, unsigned char *to, int tolen) {
+    return BN_bn2le_padded(to, tolen, a);
+}
+#endif
+
 #ifndef BN_OPENSSL_DISABLE
 // Convert BIGNUM into MB8(Radix=2^52) format
 // Returns bitmask of succesfully converted values


### PR DESCRIPTION
In case BoringSSL is used instead of OpenSSL, one function needs to be called differently (BoringSSL doesn't have `BN_bn2lebinpad()` defined). Protect the change with BoringSSL build-time `#define`.