### PR TITLE
Remove BoringSSL-specific definition of BN_bn2lebinpad

### DIFF
--- a/sources/ippcp/crypto_mb/src/common/ifma_cvt52.c
+++ b/sources/ippcp/crypto_mb/src/common/ifma_cvt52.c
@@ -168,12 +168,6 @@ __INLINE void transform_8sb_to_mb8(U64 out_mb8[], int bitLen, int8u *inp[8], int
    }
 }
 
-#ifdef OPENSSL_IS_BORINGSSL
-static int BN_bn2lebinpad(const BIGNUM *a, unsigned char *to, int tolen) {
-    return BN_bn2le_padded(to, tolen, a);
-}
-#endif
-
 #ifndef BN_OPENSSL_DISABLE
 // Convert BIGNUM into MB8(Radix=2^52) format
 // Returns bitmask of succesfully converted values


### PR DESCRIPTION
Envoy is trying to upgrade its BoringSSL dependency (https://github.com/envoyproxy/envoy/pull/30001), and we need to remove this BoringSSL-specific re-definition of `BN_bn2lebinpad`, since this was introduced to BoringSSL directly in https://boringssl.googlesource.com/boringssl/+/004317217f81b14c764748f42c5ea88fd05fea3c