### PR TITLE
Fix Debug build for Linux

### DIFF
--- a/sources/ippcp/crypto_mb/src/cmake/linux/Intel.cmake
+++ b/sources/ippcp/crypto_mb/src/cmake/linux/Intel.cmake
@@ -28,9 +28,11 @@ set(LINK_FLAG_SECURITY "${LINK_FLAG_SECURITY} -Wl,-z,noexecstack")
 set(CMAKE_C_FLAGS_SECURITY "")
 # Format string vulnerabilities
 set(CMAKE_C_FLAGS_SECURITY "${CMAKE_C_FLAGS_SECURITY} -Wformat -Wformat-security -Werror=format-security")
-if(NOT DEFINED NO_FORTIFY_SOURCE)
-    # Security flag that adds compile-time and run-time checks
-    set(CMAKE_C_FLAGS_SECURITY "${CMAKE_C_FLAGS_SECURITY} -D_FORTIFY_SOURCE=2")
+if(${CMAKE_BUILD_TYPE} STREQUAL "Release")
+    if(NOT DEFINED NO_FORTIFY_SOURCE)
+        # Security flag that adds compile-time and run-time checks
+        set(CMAKE_C_FLAGS_SECURITY "${CMAKE_C_FLAGS_SECURITY} -D_FORTIFY_SOURCE=2")
+    endif()
 endif()
 # Stack-based Buffer Overrun Detection
 set(CMAKE_C_FLAGS_SECURITY "${CMAKE_C_FLAGS_SECURITY} -fstack-protector")

--- a/sources/ippcp/crypto_mb/src/cmake/linux/IntelLLVM.cmake
+++ b/sources/ippcp/crypto_mb/src/cmake/linux/IntelLLVM.cmake
@@ -28,9 +28,11 @@ set(LINK_FLAG_SECURITY "${LINK_FLAG_SECURITY} -Wl,-z,noexecstack")
 set(CMAKE_C_FLAGS_SECURITY "")
 # Format string vulnerabilities
 set(CMAKE_C_FLAGS_SECURITY "${CMAKE_C_FLAGS_SECURITY} -Wformat -Wformat-security -Werror=format-security")
-if(NOT DEFINED NO_FORTIFY_SOURCE)
-    # Security flag that adds compile-time and run-time checks
-    set(CMAKE_C_FLAGS_SECURITY "${CMAKE_C_FLAGS_SECURITY} -D_FORTIFY_SOURCE=2")
+if(${CMAKE_BUILD_TYPE} STREQUAL "Release")
+    if(NOT DEFINED NO_FORTIFY_SOURCE)
+        # Security flag that adds compile-time and run-time checks
+        set(CMAKE_C_FLAGS_SECURITY "${CMAKE_C_FLAGS_SECURITY} -D_FORTIFY_SOURCE=2")
+    endif()
 endif()
 # Stack-based Buffer Overrun Detection
 set(CMAKE_C_FLAGS_SECURITY "${CMAKE_C_FLAGS_SECURITY} -fstack-protector")


### PR DESCRIPTION
When building Linux debug, a build warning will be raised that compiler optimisation is needed due to _FORTIFY_SOURCE is defined to 2.
This PR fixes the Intel compiler flags to set _FORTIFY_SOURCE only in Release build.