### PR TITLE
Use raw strings for python regexes to avoid syntax warnings

### DIFF
--- a/sources/dispatcher/gen_disp_common.py
+++ b/sources/dispatcher/gen_disp_common.py
@@ -30,35 +30,35 @@ def readNextFunction(header, curLine, headerID):    ## read next function with a
   FunType  = ''
   success = False
   while (curLine < len(header) and success == False):
-    if not headerID and re.match( '\s*#\s*if\s*!\s*defined\s*\(\s*__IPP', header[curLine]):
-      headerID= re.sub( '.*__IPP', '__IPP', header[curLine] )
-      headerID= re.sub( "\)", '', headerID)
-      headerID= re.sub( '[\n\s]', '', headerID )
+    if not headerID and re.match(r'\s*#\s*if\s*!\s*defined\s*\(\s*__IPP', header[curLine]):
+      headerID= re.sub(r'.*__IPP', '__IPP', header[curLine] )
+      headerID= re.sub(r"\)", '', headerID)
+      headerID= re.sub(r'[\n\s]', '', headerID )
     
-    if re.match( '^\s*IPPAPI\s*\(.*', header[curLine] ) :
+    if re.match(r'^\s*IPPAPI\s*\(.*', header[curLine] ) :
       FunStr= header[curLine];
-      FunStr= re.sub('\n','',FunStr)   ## remove EOL symbols
+      FunStr= re.sub(r'\n','',FunStr)   ## remove EOL symbols
   
-      while not re.match('.*\)\s*\)\s*$', FunStr):   ## concatenate string if string is not completed
+      while not re.match(r'.*\)\s*\)\s*$', FunStr):   ## concatenate string if string is not completed
         curLine= curLine+1
         FunStr= FunStr+header[curLine]
-        FunStr= re.sub('\n','',FunStr)   ## remove EOL symbols
+        FunStr= re.sub(r'\n','',FunStr)   ## remove EOL symbols
     
-      FunStr= re.sub('\s+', ' ', FunStr)
+      FunStr= re.sub(r'\s+', ' ', FunStr)
     
       s= FunStr.split(',')
     
       ## Extract function name
       FunName= s[1]
-      FunName= re.sub('\s', '', FunName)
+      FunName= re.sub(r'\s', '', FunName)
     
       ## Extract function type
-      FunType= re.sub( '.*\(', '', s[0] )
-      #FunType= re.sub(' ', '', FunType )
+      FunType= re.sub(r'.*\(', '', s[0] )
+      #FunType= re.sub(r' ', '', FunType )
     
       ## Extract function arguments
-      FunArg= re.sub('.*\(.*,.+,\s*\(', '(', FunStr)
-      FunArg= re.sub('\)\s*\)', ')', FunArg)
+      FunArg= re.sub(r'.*\(.*,.+,\s*\(', '(', FunStr)
+      FunArg= re.sub(r'\)\s*\)', ')', FunArg)
       success = True
 
     curLine = curLine + 1

--- a/sources/ippcp/crypto_mb/dispatcher/gen_disp_common_crypto_mb.py
+++ b/sources/ippcp/crypto_mb/dispatcher/gen_disp_common_crypto_mb.py
@@ -31,42 +31,42 @@ def readNextFunction(header, curLine, headerID):    ## read next function with a
   FunArgCall = ''
   success = False
   while (curLine < len(header) and success == False):
-    if not headerID and re.match( '\s*#\s*if\s*!\s*defined\s*\(\s*__IPP', header[curLine]):
-      headerID= re.sub( '.*__IPP', '__IPP', header[curLine] )
-      headerID= re.sub( "\)", '', headerID)
-      headerID= re.sub( '[\n\s]', '', headerID )
+    if not headerID and re.match(r'\s*#\s*if\s*!\s*defined\s*\(\s*__IPP', header[curLine]):
+      headerID= re.sub(r'.*__IPP', '__IPP', header[curLine] )
+      headerID= re.sub(r"\)", '', headerID)
+      headerID= re.sub(r'[\n\s]', '', headerID )
     
-    if re.match( '^\s*MBXAPI\s*\(.*', header[curLine] ) :
+    if re.match(r'^\s*MBXAPI\s*\(.*', header[curLine] ) :
       FunStr= header[curLine]
-      FunStr= re.sub('\n','',FunStr)   ## remove EOL symbols
+      FunStr= re.sub(r'\n','',FunStr)   ## remove EOL symbols
   
-      while not re.match('.*\)\s*\)\s*$', FunStr):   ## concatenate string if string is not completed
+      while not re.match(r'.*\)\s*\)\s*$', FunStr):   ## concatenate string if string is not completed
         curLine= curLine+1
         FunStr= FunStr+header[curLine]
-        FunStr= re.sub('\n','',FunStr)   ## remove EOL symbols
+        FunStr= re.sub(r'\n','',FunStr)   ## remove EOL symbols
     
-      FunStr= re.sub('\s+', ' ', FunStr)
+      FunStr= re.sub(r'\s+', ' ', FunStr)
     
       s= FunStr.split(',')
     
       ## Extract function name
       FunName= s[1]
-      FunName= re.sub('\s', '', FunName)
+      FunName= re.sub(r'\s', '', FunName)
     
       ## Extract function type
-      FunType= re.sub( '.*\(', '', s[0] )
+      FunType= re.sub(r'.*\(', '', s[0] )
     
       ## Extract function arguments
-      FunArg= re.sub('.*\(.*,.+,\s*\(', '(', FunStr)
-      FunArg= re.sub('\)\s*\)', ')', FunArg)
+      FunArg= re.sub(r'.*\(.*,.+,\s*\(', '(', FunStr)
+      FunArg= re.sub(r'\)\s*\)', ')', FunArg)
 
       ## Extract function arguments for call
       s= FunArg.split(',')
       for i in s:
         l= i.split(' ')
         FunArgCall+= l[-1] + ', '
-        FunArgCall= re.sub('\[\w*\]', '', FunArgCall)
-        FunArgCall= re.sub('\*', '', FunArgCall)
+        FunArgCall= re.sub(r'\[\w*\]', '', FunArgCall)
+        FunArgCall= re.sub(r'\*', '', FunArgCall)
       FunArgCall= FunArgCall[:-2]
       FunArgCall= '(' + FunArgCall
 


### PR DESCRIPTION
Running cmake on a platform with Python >= 3.12 generates many warnings about invalid escapes in regex strings:

```
sources/gen_cpu_spc_header/../dispatcher/gen_disp_common.py:33: SyntaxWarning: invalid escape sequence '\s'
  if not headerID and re.match( '\s*#\s*if\s*!\s*defined\s*\(\s*__IPP', header[curLine]):
sources/gen_cpu_spc_header/../dispatcher/gen_disp_common.py:35: SyntaxWarning: invalid escape sequence '\)'
  headerID= re.sub( "\)", '', headerID)
sources/gen_cpu_spc_header/../dispatcher/gen_disp_common.py:36: SyntaxWarning: invalid escape sequence '\s'
  headerID= re.sub( '[\n\s]', '', headerID )
sources/gen_cpu_spc_header/../dispatcher/gen_disp_common.py:38: SyntaxWarning: invalid escape sequence '\s'
  if re.match( '^\s*IPPAPI\s*\(.*', header[curLine] ) :
sources/gen_cpu_spc_header/../dispatcher/gen_disp_common.py:42: SyntaxWarning: invalid escape sequence '\)'
  while not re.match('.*\)\s*\)\s*$', FunStr):   ## concatenate string if string is not completed
sources/gen_cpu_spc_header/../dispatcher/gen_disp_common.py:47: SyntaxWarning: invalid escape sequence '\s'
  FunStr= re.sub('\s+', ' ', FunStr)
sources/gen_cpu_spc_header/../dispatcher/gen_disp_common.py:53: SyntaxWarning: invalid escape sequence '\s'
  FunName= re.sub('\s', '', FunName)
sources/gen_cpu_spc_header/../dispatcher/gen_disp_common.py:56: SyntaxWarning: invalid escape sequence '\('
  FunType= re.sub( '.*\(', '', s[0] )
sources/gen_cpu_spc_header/../dispatcher/gen_disp_common.py:60: SyntaxWarning: invalid escape sequence '\('
  FunArg= re.sub('.*\(.*,.+,\s*\(', '(', FunStr)
sources/gen_cpu_spc_header/../dispatcher/gen_disp_common.py:61: SyntaxWarning: invalid escape sequence '\)'
  FunArg= re.sub('\)\s*\)', ')', FunArg)
-- CMAKE_BUILD_TYPE is not set to Debug explicitly, defaulting to Release
-- Found OpenSSL: /usr/lib64/libcrypto.so (found suitable version "3.2.2", minimum required is "3.0.8")
sources/ippcp/crypto_mb/gen_cpu_spc_header/../dispatcher/gen_disp_common_crypto_mb.py:34: SyntaxWarning: invalid escape sequence '\s'
  if not headerID and re.match( '\s*#\s*if\s*!\s*defined\s*\(\s*__IPP', header[curLine]):
sources/ippcp/crypto_mb/gen_cpu_spc_header/../dispatcher/gen_disp_common_crypto_mb.py:36: SyntaxWarning: invalid escape sequence '\)'
  headerID= re.sub( "\)", '', headerID)
sources/ippcp/crypto_mb/gen_cpu_spc_header/../dispatcher/gen_disp_common_crypto_mb.py:37: SyntaxWarning: invalid escape sequence '\s'
  headerID= re.sub( '[\n\s]', '', headerID )
sources/ippcp/crypto_mb/gen_cpu_spc_header/../dispatcher/gen_disp_common_crypto_mb.py:39: SyntaxWarning: invalid escape sequence '\s'
  if re.match( '^\s*MBXAPI\s*\(.*', header[curLine] ) :
sources/ippcp/crypto_mb/gen_cpu_spc_header/../dispatcher/gen_disp_common_crypto_mb.py:43: SyntaxWarning: invalid escape sequence '\)'
  while not re.match('.*\)\s*\)\s*$', FunStr):   ## concatenate string if string is not completed
sources/ippcp/crypto_mb/gen_cpu_spc_header/../dispatcher/gen_disp_common_crypto_mb.py:48: SyntaxWarning: invalid escape sequence '\s'
  FunStr= re.sub('\s+', ' ', FunStr)
sources/ippcp/crypto_mb/gen_cpu_spc_header/../dispatcher/gen_disp_common_crypto_mb.py:54: SyntaxWarning: invalid escape sequence '\s'
  FunName= re.sub('\s', '', FunName)
sources/ippcp/crypto_mb/gen_cpu_spc_header/../dispatcher/gen_disp_common_crypto_mb.py:57: SyntaxWarning: invalid escape sequence '\('
  FunType= re.sub( '.*\(', '', s[0] )
sources/ippcp/crypto_mb/gen_cpu_spc_header/../dispatcher/gen_disp_common_crypto_mb.py:60: SyntaxWarning: invalid escape sequence '\('
  FunArg= re.sub('.*\(.*,.+,\s*\(', '(', FunStr)
sources/ippcp/crypto_mb/gen_cpu_spc_header/../dispatcher/gen_disp_common_crypto_mb.py:61: SyntaxWarning: invalid escape sequence '\)'
  FunArg= re.sub('\)\s*\)', ')', FunArg)
sources/ippcp/crypto_mb/gen_cpu_spc_header/../dispatcher/gen_disp_common_crypto_mb.py:68: SyntaxWarning: invalid escape sequence '\['
  FunArgCall= re.sub('\[\w*\]', '', FunArgCall)
sources/ippcp/crypto_mb/gen_cpu_spc_header/../dispatcher/gen_disp_common_crypto_mb.py:69: SyntaxWarning: invalid escape sequence '\*'
  FunArgCall= re.sub('\*', '', FunArgCall)
```

This is a new python change:

  https://docs.python.org/3/whatsnew/3.12.html#other-language-changes

```
  "A backslash-character pair that is not a valid escape
   sequence now generates a SyntaxWarning, instead of
   DeprecationWarning. For example, re.compile("\d+\.\d+")
   now emits a SyntaxWarning ("\d" is an invalid escape
   sequence, use raw strings for regular expression:
   re.compile(r"\d+\.\d+")). In a future Python version,
   SyntaxError will eventually be raised, instead of
   SyntaxWarning."
```

Given that python intends to turn this into an error in a future release, this should be proactively fixed now.

Fortunately the regexes used don't appear to need to use any genuine backslash escapes, all the backslash usage is for regex characters, so the raw string conversion is simple.