### PR TITLE
fix: avoid resetting `method.hashUpdate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This is a list of notable changes to Intel® Cryptography Primitives Library, in reverse chronological order.
 
+## Intel(R) Cryptography Primitives Library 1.1.1
+- Fixed setting the `method.hashUpdate` variable twice in `ippsHashMethod_SHA256_TT` implementation. In a multithreaded environment this destroyed memory caches. Note that to make the code cleaner I used an early return in the special `sha256_ni_hashUpdate` case. Fixes intel/linux-sgx#1073
+
 ## Intel(R) Cryptography Primitives Library 1.1.0
 
 - Added single buffer SM4 (former SMS4) algorithm with the new SM4 instructions for Lunar Lake and Arrow Lake S CPUs.

--- a/sources/ippcp/hash/sha1/pcphashmethod_sha1_tt.c
+++ b/sources/ippcp/hash/sha1/pcphashmethod_sha1_tt.c
@@ -46,29 +46,25 @@
 //
 *F*/
 
-IPPFUN( const IppsHashMethod*, ippsHashMethod_SHA1_TT, (void) )
+IPPFUN(const IppsHashMethod*, ippsHashMethod_SHA1_TT, (void))
 {
-   static IppsHashMethod method = {
-      ippHashAlg_SHA1,
-      IPP_SHA1_DIGEST_BITSIZE/8,
-      MBS_SHA1,
-      MLR_SHA1,
-      NULL,
-      NULL,
-      NULL,
-      NULL,
-   };
+    static IppsHashMethod method = {
+        ippHashAlg_SHA1, IPP_SHA1_DIGEST_BITSIZE / 8, MBS_SHA1, MLR_SHA1, NULL, NULL, NULL, NULL,
+    };
 
-   // don't merge `method` initialization with function pointers assignment
-   // to prevent relocations (indirect calls) to be generated in the binary
-   method.hashInit   = sha1_hashInit;
-   method.hashUpdate = sha1_hashUpdate;
-   method.hashOctStr = sha1_hashOctString;
-   method.msgLenRep  = sha1_msgRep;
+    // don't merge `method` initialization with function pointers assignment
+    // to prevent relocations (indirect calls) to be generated in the binary
+    method.hashInit   = sha1_hashInit;
+    method.hashOctStr = sha1_hashOctString;
+    method.msgLenRep  = sha1_msgRep;
 
-   #if (_SHA_NI_ENABLING_==_FEATURE_TICKTOCK_ || _SHA_NI_ENABLING_==_FEATURE_ON_)
-   if(IsFeatureEnabled(ippCPUID_SHA))
-      method.hashUpdate = sha1_ni_hashUpdate;
-   #endif
-   return &method;
+#if (_SHA_NI_ENABLING_ == _FEATURE_TICKTOCK_ || _SHA_NI_ENABLING_ == _FEATURE_ON_)
+    if (IsFeatureEnabled(ippCPUID_SHA)) {
+        method.hashUpdate = sha1_ni_hashUpdate;
+        return &method;
+    }
+#endif
+
+    method.hashUpdate = sha1_hashUpdate;
+    return &method;
 }

--- a/sources/ippcp/hash/sha1/pcphashmethodset_sha1_tt.c
+++ b/sources/ippcp/hash/sha1/pcphashmethodset_sha1_tt.c
@@ -45,24 +45,26 @@
 //
 *F*/
 
-IPPFUN( IppStatus, ippsHashMethodSet_SHA1_TT, (IppsHashMethod* pMethod) )
+IPPFUN(IppStatus, ippsHashMethodSet_SHA1_TT, (IppsHashMethod * pMethod))
 {
-   /* test pointers */
-   IPP_BAD_PTR1_RET(pMethod);
+    /* test pointers */
+    IPP_BAD_PTR1_RET(pMethod);
 
-   pMethod->hashAlgId     = ippHashAlg_SHA1;
-   pMethod->hashLen       = IPP_SHA1_DIGEST_BITSIZE/8;
-   pMethod->msgBlkSize    = MBS_SHA1;
-   pMethod->msgLenRepSize = MLR_SHA1;
-   pMethod->hashInit      = sha1_hashInit;
-   pMethod->hashUpdate    = sha1_hashUpdate;
-   pMethod->hashOctStr    = sha1_hashOctString;
-   pMethod->msgLenRep     = sha1_msgRep;
+    pMethod->hashAlgId     = ippHashAlg_SHA1;
+    pMethod->hashLen       = IPP_SHA1_DIGEST_BITSIZE / 8;
+    pMethod->msgBlkSize    = MBS_SHA1;
+    pMethod->msgLenRepSize = MLR_SHA1;
+    pMethod->hashInit      = sha1_hashInit;
+    pMethod->hashOctStr    = sha1_hashOctString;
+    pMethod->msgLenRep     = sha1_msgRep;
 
-#if (_SHA_NI_ENABLING_==_FEATURE_TICKTOCK_ || _SHA_NI_ENABLING_==_FEATURE_ON_)
-   if(IsFeatureEnabled(ippCPUID_SHA))
-      pMethod->hashUpdate = sha1_ni_hashUpdate;
+#if (_SHA_NI_ENABLING_ == _FEATURE_TICKTOCK_ || _SHA_NI_ENABLING_ == _FEATURE_ON_)
+    if (IsFeatureEnabled(ippCPUID_SHA)) {
+        pMethod->hashUpdate = sha1_ni_hashUpdate;
+        return ippStsNoErr;
+    }
 #endif
 
-   return ippStsNoErr;
+    pMethod->hashUpdate = sha1_hashUpdate;
+    return ippStsNoErr;
 }

--- a/sources/ippcp/hash/sha224/pcphashmethod_sha224_tt.c
+++ b/sources/ippcp/hash/sha224/pcphashmethod_sha224_tt.c
@@ -46,29 +46,32 @@
 //
 *F*/
 
-IPPFUN( const IppsHashMethod*, ippsHashMethod_SHA224_TT, (void) )
+IPPFUN(const IppsHashMethod*, ippsHashMethod_SHA224_TT, (void))
 {
-   static IppsHashMethod method = {
-      ippHashAlg_SHA224,
-      IPP_SHA224_DIGEST_BITSIZE/8,
-      MBS_SHA256,
-      MLR_SHA256,
-      NULL,
-      NULL,
-      NULL,
-      NULL,
-   };
+    static IppsHashMethod method = {
+        ippHashAlg_SHA224,
+        IPP_SHA224_DIGEST_BITSIZE / 8,
+        MBS_SHA256,
+        MLR_SHA256,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+    };
 
-   // don't merge `method` initialization with function pointers assignment
-   // to prevent relocations (indirect calls) to be generated in the binary
-   method.hashInit   = sha224_hashInit;
-   method.hashUpdate = sha256_hashUpdate;
-   method.hashOctStr = sha224_hashOctString;
-   method.msgLenRep  = sha256_msgRep;
+    // don't merge `method` initialization with function pointers assignment
+    // to prevent relocations (indirect calls) to be generated in the binary
+    method.hashInit   = sha224_hashInit;
+    method.hashOctStr = sha224_hashOctString;
+    method.msgLenRep  = sha256_msgRep;
 
-   #if (_SHA_NI_ENABLING_==_FEATURE_TICKTOCK_ || _SHA_NI_ENABLING_==_FEATURE_ON_)
-   if(IsFeatureEnabled(ippCPUID_SHA))
-      method.hashUpdate = sha256_ni_hashUpdate;
-   #endif
-   return &method;
+#if (_SHA_NI_ENABLING_ == _FEATURE_TICKTOCK_ || _SHA_NI_ENABLING_ == _FEATURE_ON_)
+    if (IsFeatureEnabled(ippCPUID_SHA)) {
+        method.hashUpdate = sha256_ni_hashUpdate;
+        return &method;
+    }
+#endif
+
+    method.hashUpdate = sha256_hashUpdate;
+    return &method;
 }

--- a/sources/ippcp/hash/sha224/pcphashmethodset_sha224_tt.c
+++ b/sources/ippcp/hash/sha224/pcphashmethodset_sha224_tt.c
@@ -45,24 +45,26 @@
 //
 *F*/
 
-IPPFUN( IppStatus, ippsHashMethodSet_SHA224_TT, (IppsHashMethod* pMethod) )
+IPPFUN(IppStatus, ippsHashMethodSet_SHA224_TT, (IppsHashMethod * pMethod))
 {
-   /* test pointers */
-   IPP_BAD_PTR1_RET(pMethod);
+    /* test pointers */
+    IPP_BAD_PTR1_RET(pMethod);
 
-   pMethod->hashAlgId     = ippHashAlg_SHA224;
-   pMethod->hashLen       = IPP_SHA224_DIGEST_BITSIZE/8;
-   pMethod->msgBlkSize    = MBS_SHA256;
-   pMethod->msgLenRepSize = MLR_SHA256;
-   pMethod->hashInit      = sha224_hashInit;
-   pMethod->hashUpdate    = sha256_hashUpdate;
-   pMethod->hashOctStr    = sha224_hashOctString;
-   pMethod->msgLenRep     = sha256_msgRep;
+    pMethod->hashAlgId     = ippHashAlg_SHA224;
+    pMethod->hashLen       = IPP_SHA224_DIGEST_BITSIZE / 8;
+    pMethod->msgBlkSize    = MBS_SHA256;
+    pMethod->msgLenRepSize = MLR_SHA256;
+    pMethod->hashInit      = sha224_hashInit;
+    pMethod->hashOctStr    = sha224_hashOctString;
+    pMethod->msgLenRep     = sha256_msgRep;
 
-#if (_SHA_NI_ENABLING_==_FEATURE_TICKTOCK_ || _SHA_NI_ENABLING_==_FEATURE_ON_)
-   if(IsFeatureEnabled(ippCPUID_SHA))
-      pMethod->hashUpdate = sha256_ni_hashUpdate;
+#if (_SHA_NI_ENABLING_ == _FEATURE_TICKTOCK_ || _SHA_NI_ENABLING_ == _FEATURE_ON_)
+    if (IsFeatureEnabled(ippCPUID_SHA)) {
+        pMethod->hashUpdate = sha256_ni_hashUpdate;
+        return ippStsNoErr;
+    }
 #endif
 
-   return ippStsNoErr;
+    pMethod->hashUpdate = sha256_hashUpdate;
+    return ippStsNoErr;
 }

--- a/sources/ippcp/hash/sha224/pcphashstatemethodset_sha224_tt.c
+++ b/sources/ippcp/hash/sha224/pcphashstatemethodset_sha224_tt.c
@@ -45,26 +45,30 @@
 //
 *F*/
 
-IPPFUN( IppStatus, ippsHashStateMethodSet_SHA224_TT, (IppsHashState_rmf* pState, IppsHashMethod* pMethod) )
+IPPFUN(IppStatus,
+       ippsHashStateMethodSet_SHA224_TT,
+       (IppsHashState_rmf * pState, IppsHashMethod* pMethod))
 {
-   /* test pointers */
-   IPP_BAD_PTR2_RET(pState, pMethod);
+    /* test pointers */
+    IPP_BAD_PTR2_RET(pState, pMethod);
 
-   HASH_METHOD(pState) = pMethod;
+    HASH_METHOD(pState) = pMethod;
 
-   pMethod->hashAlgId     = ippHashAlg_SHA224;
-   pMethod->hashLen       = IPP_SHA224_DIGEST_BITSIZE/8;
-   pMethod->msgBlkSize    = MBS_SHA256;
-   pMethod->msgLenRepSize = MLR_SHA256;
-   pMethod->hashInit      = sha224_hashInit;
-   pMethod->hashUpdate    = sha256_hashUpdate;
-   pMethod->hashOctStr    = sha224_hashOctString;
-   pMethod->msgLenRep     = sha256_msgRep;
+    pMethod->hashAlgId     = ippHashAlg_SHA224;
+    pMethod->hashLen       = IPP_SHA224_DIGEST_BITSIZE / 8;
+    pMethod->msgBlkSize    = MBS_SHA256;
+    pMethod->msgLenRepSize = MLR_SHA256;
+    pMethod->hashInit      = sha224_hashInit;
+    pMethod->hashOctStr    = sha224_hashOctString;
+    pMethod->msgLenRep     = sha256_msgRep;
 
-#if (_SHA_NI_ENABLING_==_FEATURE_TICKTOCK_ || _SHA_NI_ENABLING_==_FEATURE_ON_)
-   if(IsFeatureEnabled(ippCPUID_SHA))
-      pMethod->hashUpdate = sha256_ni_hashUpdate;
+#if (_SHA_NI_ENABLING_ == _FEATURE_TICKTOCK_ || _SHA_NI_ENABLING_ == _FEATURE_ON_)
+    if (IsFeatureEnabled(ippCPUID_SHA)) {
+        pMethod->hashUpdate = sha256_ni_hashUpdate;
+        return ippStsNoErr;
+    }
 #endif
 
-   return ippStsNoErr;
+    pMethod->hashUpdate = sha256_hashUpdate;
+    return ippStsNoErr;
 }

--- a/sources/ippcp/hash/sha256/pcphashmethod_sha256_tt.c
+++ b/sources/ippcp/hash/sha256/pcphashmethod_sha256_tt.c
@@ -46,30 +46,32 @@
 //
 *F*/
 
-IPPFUN( const IppsHashMethod*, ippsHashMethod_SHA256_TT, (void) )
+IPPFUN(const IppsHashMethod*, ippsHashMethod_SHA256_TT, (void))
 {
-   static IppsHashMethod method = {
-      ippHashAlg_SHA256,
-      IPP_SHA256_DIGEST_BITSIZE/8,
-      MBS_SHA256,
-      MLR_SHA256,
-      NULL,
-      NULL,
-      NULL,
-      NULL,
-   };
+    static IppsHashMethod method = {
+        ippHashAlg_SHA256,
+        IPP_SHA256_DIGEST_BITSIZE / 8,
+        MBS_SHA256,
+        MLR_SHA256,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+    };
 
-   // don't merge `method` initialization with function pointers assignment
-   // to prevent relocations (indirect calls) to be generated in the binary
-   method.hashInit   = sha256_hashInit;
-   method.hashUpdate = sha256_hashUpdate;
-   method.hashOctStr = sha256_hashOctString;
-   method.msgLenRep  = sha256_msgRep;
+    // don't merge `method` initialization with function pointers assignment
+    // to prevent relocations (indirect calls) to be generated in the binary
+    method.hashInit   = sha256_hashInit;
+    method.hashOctStr = sha256_hashOctString;
+    method.msgLenRep  = sha256_msgRep;
 
-#if (_SHA_NI_ENABLING_==_FEATURE_TICKTOCK_ || _SHA_NI_ENABLING_==_FEATURE_ON_)
-   if(IsFeatureEnabled(ippCPUID_SHA))
-      method.hashUpdate = sha256_ni_hashUpdate;
+#if (_SHA_NI_ENABLING_ == _FEATURE_TICKTOCK_ || _SHA_NI_ENABLING_ == _FEATURE_ON_)
+    if (IsFeatureEnabled(ippCPUID_SHA)) {
+        method.hashUpdate = sha256_ni_hashUpdate;
+        return &method;
+    }
 #endif
+    method.hashUpdate = sha256_hashUpdate;
 
-   return &method;
+    return &method;
 }

--- a/sources/ippcp/hash/sha256/pcphashmethod_sha256_tt.c
+++ b/sources/ippcp/hash/sha256/pcphashmethod_sha256_tt.c
@@ -71,7 +71,7 @@ IPPFUN(const IppsHashMethod*, ippsHashMethod_SHA256_TT, (void))
         return &method;
     }
 #endif
-    method.hashUpdate = sha256_hashUpdate;
 
+    method.hashUpdate = sha256_hashUpdate;
     return &method;
 }

--- a/sources/ippcp/hash/sha256/pcphashmethodset_sha256_tt.c
+++ b/sources/ippcp/hash/sha256/pcphashmethodset_sha256_tt.c
@@ -45,24 +45,26 @@
 //
 *F*/
 
-IPPFUN( IppStatus, ippsHashMethodSet_SHA256_TT, (IppsHashMethod* pMethod) )
+IPPFUN(IppStatus, ippsHashMethodSet_SHA256_TT, (IppsHashMethod * pMethod))
 {
-   /* test pointers */
-   IPP_BAD_PTR1_RET(pMethod);
+    /* test pointers */
+    IPP_BAD_PTR1_RET(pMethod);
 
-   pMethod->hashAlgId     =  ippHashAlg_SHA256;
-   pMethod->hashLen       =  IPP_SHA256_DIGEST_BITSIZE/8;
-   pMethod->msgBlkSize    =  MBS_SHA256;
-   pMethod->msgLenRepSize =  MLR_SHA256;
-   pMethod->hashInit      =  sha256_hashInit;
-   pMethod->hashUpdate    =  sha256_hashUpdate;
-   pMethod->hashOctStr    =  sha256_hashOctString;
-   pMethod->msgLenRep     =  sha256_msgRep;
+    pMethod->hashAlgId     = ippHashAlg_SHA256;
+    pMethod->hashLen       = IPP_SHA256_DIGEST_BITSIZE / 8;
+    pMethod->msgBlkSize    = MBS_SHA256;
+    pMethod->msgLenRepSize = MLR_SHA256;
+    pMethod->hashInit      = sha256_hashInit;
+    pMethod->hashOctStr    = sha256_hashOctString;
+    pMethod->msgLenRep     = sha256_msgRep;
 
-#if (_SHA_NI_ENABLING_==_FEATURE_TICKTOCK_ || _SHA_NI_ENABLING_==_FEATURE_ON_)
-   if(IsFeatureEnabled(ippCPUID_SHA))
-      pMethod->hashUpdate = sha256_ni_hashUpdate;
+#if (_SHA_NI_ENABLING_ == _FEATURE_TICKTOCK_ || _SHA_NI_ENABLING_ == _FEATURE_ON_)
+    if (IsFeatureEnabled(ippCPUID_SHA)) {
+        pMethod->hashUpdate = sha256_ni_hashUpdate;
+        return ippStsNoErr;
+    }
 #endif
 
-   return ippStsNoErr;
+    pMethod->hashUpdate = sha256_hashUpdate;
+    return ippStsNoErr;
 }

--- a/sources/ippcp/hash/sha256/pcphashstatemethodset_sha256_tt.c
+++ b/sources/ippcp/hash/sha256/pcphashstatemethodset_sha256_tt.c
@@ -45,26 +45,30 @@
 //
 *F*/
 
-IPPFUN( IppStatus, ippsHashStateMethodSet_SHA256_TT, (IppsHashState_rmf* pState, IppsHashMethod* pMethod) )
+IPPFUN(IppStatus,
+       ippsHashStateMethodSet_SHA256_TT,
+       (IppsHashState_rmf * pState, IppsHashMethod* pMethod))
 {
-   /* test pointers */
-   IPP_BAD_PTR2_RET(pState, pMethod);
+    /* test pointers */
+    IPP_BAD_PTR2_RET(pState, pMethod);
 
-   HASH_METHOD(pState) = pMethod;
+    HASH_METHOD(pState) = pMethod;
 
-   pMethod->hashAlgId     =  ippHashAlg_SHA256;
-   pMethod->hashLen       =  IPP_SHA256_DIGEST_BITSIZE/8;
-   pMethod->msgBlkSize    =  MBS_SHA256;
-   pMethod->msgLenRepSize =  MLR_SHA256;
-   pMethod->hashInit      =  sha256_hashInit;
-   pMethod->hashUpdate    =  sha256_hashUpdate;
-   pMethod->hashOctStr    =  sha256_hashOctString;
-   pMethod->msgLenRep     =  sha256_msgRep;
+    pMethod->hashAlgId     = ippHashAlg_SHA256;
+    pMethod->hashLen       = IPP_SHA256_DIGEST_BITSIZE / 8;
+    pMethod->msgBlkSize    = MBS_SHA256;
+    pMethod->msgLenRepSize = MLR_SHA256;
+    pMethod->hashInit      = sha256_hashInit;
+    pMethod->hashOctStr    = sha256_hashOctString;
+    pMethod->msgLenRep     = sha256_msgRep;
 
-#if (_SHA_NI_ENABLING_==_FEATURE_TICKTOCK_ || _SHA_NI_ENABLING_==_FEATURE_ON_)
-   if(IsFeatureEnabled(ippCPUID_SHA))
-      pMethod->hashUpdate = sha256_ni_hashUpdate;
+#if (_SHA_NI_ENABLING_ == _FEATURE_TICKTOCK_ || _SHA_NI_ENABLING_ == _FEATURE_ON_)
+    if (IsFeatureEnabled(ippCPUID_SHA)) {
+        pMethod->hashUpdate = sha256_ni_hashUpdate;
+        return ippStsNoErr;
+    }
 #endif
 
-   return ippStsNoErr;
+    pMethod->hashUpdate = sha256_hashUpdate;
+    return ippStsNoErr;
 }

--- a/sources/ippcp/hash/sha384/pcphashmethod_sha384_tt.c
+++ b/sources/ippcp/hash/sha384/pcphashmethod_sha384_tt.c
@@ -44,30 +44,30 @@
 //
 *F*/
 
-IPPFUN( const IppsHashMethod*, ippsHashMethod_SHA384_TT, (void) )
+IPPFUN(const IppsHashMethod*, ippsHashMethod_SHA384_TT, (void))
 {
-   static IppsHashMethod method = {
-      ippHashAlg_SHA384,
-      IPP_SHA384_DIGEST_BITSIZE/8,
-      MBS_SHA512,
-      MLR_SHA512,
-      NULL,
-      NULL,
-      NULL,
-      NULL
-   };
+    static IppsHashMethod method = { ippHashAlg_SHA384,
+                                     IPP_SHA384_DIGEST_BITSIZE / 8,
+                                     MBS_SHA512,
+                                     MLR_SHA512,
+                                     NULL,
+                                     NULL,
+                                     NULL,
+                                     NULL };
 
-   // don't merge `method` initialization with function pointers assignment
-   // to prevent relocations (indirect calls) to be generated in the binary
-   method.hashInit   = sha512_384_hashInit;
-   method.hashUpdate = sha512_hashUpdate;
-   method.hashOctStr = sha512_384_hashOctString;
-   method.msgLenRep  = sha512_msgRep;
+    // don't merge `method` initialization with function pointers assignment
+    // to prevent relocations (indirect calls) to be generated in the binary
+    method.hashInit   = sha512_384_hashInit;
+    method.hashOctStr = sha512_384_hashOctString;
+    method.msgLenRep  = sha512_msgRep;
 
-#if (_SHA512_ENABLING_==_FEATURE_TICKTOCK_ || _SHA512_ENABLING_==_FEATURE_ON_)
-   if(IsFeatureEnabled(ippCPUID_AVX2SHA512))
-      method.hashUpdate = sha512_hashUpdate_ni;
+#if (_SHA512_ENABLING_ == _FEATURE_TICKTOCK_ || _SHA512_ENABLING_ == _FEATURE_ON_)
+    if (IsFeatureEnabled(ippCPUID_AVX2SHA512)) {
+        method.hashUpdate = sha512_hashUpdate_ni;
+        return &method;
+    }
 #endif
 
-   return &method;
+    method.hashUpdate = sha512_hashUpdate;
+    return &method;
 }

--- a/sources/ippcp/hash/sha384/pcphashmethodset_sha384_tt.c
+++ b/sources/ippcp/hash/sha384/pcphashmethodset_sha384_tt.c
@@ -44,24 +44,26 @@
 //
 *F*/
 
-IPPFUN( IppStatus, ippsHashMethodSet_SHA384_TT, (IppsHashMethod* pMethod) )
+IPPFUN(IppStatus, ippsHashMethodSet_SHA384_TT, (IppsHashMethod * pMethod))
 {
-   /* test pointers */
-   IPP_BAD_PTR1_RET(pMethod);
+    /* test pointers */
+    IPP_BAD_PTR1_RET(pMethod);
 
-   pMethod->hashAlgId     = ippHashAlg_SHA384;
-   pMethod->hashLen       = IPP_SHA384_DIGEST_BITSIZE/8;
-   pMethod->msgBlkSize    = MBS_SHA512;
-   pMethod->msgLenRepSize = MLR_SHA512;
-   pMethod->hashInit      = sha512_384_hashInit;
-   pMethod->hashUpdate    = sha512_hashUpdate;
-   pMethod->hashOctStr    = sha512_384_hashOctString;
-   pMethod->msgLenRep     = sha512_msgRep;
+    pMethod->hashAlgId     = ippHashAlg_SHA384;
+    pMethod->hashLen       = IPP_SHA384_DIGEST_BITSIZE / 8;
+    pMethod->msgBlkSize    = MBS_SHA512;
+    pMethod->msgLenRepSize = MLR_SHA512;
+    pMethod->hashInit      = sha512_384_hashInit;
+    pMethod->hashOctStr    = sha512_384_hashOctString;
+    pMethod->msgLenRep     = sha512_msgRep;
 
-#if (_SHA512_ENABLING_==_FEATURE_TICKTOCK_ || _SHA512_ENABLING_==_FEATURE_ON_)
-   if(IsFeatureEnabled(ippCPUID_AVX2SHA512))
-      pMethod->hashUpdate = sha512_hashUpdate_ni;
+#if (_SHA512_ENABLING_ == _FEATURE_TICKTOCK_ || _SHA512_ENABLING_ == _FEATURE_ON_)
+    if (IsFeatureEnabled(ippCPUID_AVX2SHA512)) {
+        pMethod->hashUpdate = sha512_hashUpdate_ni;
+        return ippStsNoErr;
+    }
 #endif
 
-   return ippStsNoErr;
+    pMethod->hashUpdate = sha512_hashUpdate;
+    return ippStsNoErr;
 }

--- a/sources/ippcp/hash/sha384/pcphashstatemethodset_sha384_tt.c
+++ b/sources/ippcp/hash/sha384/pcphashstatemethodset_sha384_tt.c
@@ -44,26 +44,30 @@
 //
 *F*/
 
-IPPFUN( IppStatus, ippsHashStateMethodSet_SHA384_TT, (IppsHashState_rmf* pState, IppsHashMethod* pMethod) )
+IPPFUN(IppStatus,
+       ippsHashStateMethodSet_SHA384_TT,
+       (IppsHashState_rmf * pState, IppsHashMethod* pMethod))
 {
-   /* test pointers */
-   IPP_BAD_PTR2_RET(pState, pMethod);
+    /* test pointers */
+    IPP_BAD_PTR2_RET(pState, pMethod);
 
-   HASH_METHOD(pState) = pMethod;
+    HASH_METHOD(pState) = pMethod;
 
-   pMethod->hashAlgId     = ippHashAlg_SHA384;
-   pMethod->hashLen       = IPP_SHA384_DIGEST_BITSIZE/8;
-   pMethod->msgBlkSize    = MBS_SHA512;
-   pMethod->msgLenRepSize = MLR_SHA512;
-   pMethod->hashInit      = sha512_384_hashInit;
-   pMethod->hashUpdate    = sha512_hashUpdate;
-   pMethod->hashOctStr    = sha512_384_hashOctString;
-   pMethod->msgLenRep     = sha512_msgRep;
+    pMethod->hashAlgId     = ippHashAlg_SHA384;
+    pMethod->hashLen       = IPP_SHA384_DIGEST_BITSIZE / 8;
+    pMethod->msgBlkSize    = MBS_SHA512;
+    pMethod->msgLenRepSize = MLR_SHA512;
+    pMethod->hashInit      = sha512_384_hashInit;
+    pMethod->hashOctStr    = sha512_384_hashOctString;
+    pMethod->msgLenRep     = sha512_msgRep;
 
-#if (_SHA512_ENABLING_==_FEATURE_TICKTOCK_ || _SHA512_ENABLING_==_FEATURE_ON_)
-   if(IsFeatureEnabled(ippCPUID_AVX2SHA512))
-      pMethod->hashUpdate = sha512_hashUpdate_ni;
+#if (_SHA512_ENABLING_ == _FEATURE_TICKTOCK_ || _SHA512_ENABLING_ == _FEATURE_ON_)
+    if (IsFeatureEnabled(ippCPUID_AVX2SHA512)) {
+        pMethod->hashUpdate = sha512_hashUpdate_ni;
+        return ippStsNoErr;
+    }
 #endif
 
-   return ippStsNoErr;
+    pMethod->hashUpdate = sha512_hashUpdate;
+    return ippStsNoErr;
 }

--- a/sources/ippcp/hash/sha512/pcphashmethod_sha512_224_tt.c
+++ b/sources/ippcp/hash/sha512/pcphashmethod_sha512_224_tt.c
@@ -44,30 +44,30 @@
 //
 *F*/
 
-IPPFUN( const IppsHashMethod*, ippsHashMethod_SHA512_224_TT, (void) )
+IPPFUN(const IppsHashMethod*, ippsHashMethod_SHA512_224_TT, (void))
 {
-   static IppsHashMethod method = {
-      ippHashAlg_SHA512_224,
-      IPP_SHA224_DIGEST_BITSIZE/8,
-      MBS_SHA512,
-      MLR_SHA512,
-      NULL,
-      NULL,
-      NULL,
-      NULL
-   };
+    static IppsHashMethod method = { ippHashAlg_SHA512_224,
+                                     IPP_SHA224_DIGEST_BITSIZE / 8,
+                                     MBS_SHA512,
+                                     MLR_SHA512,
+                                     NULL,
+                                     NULL,
+                                     NULL,
+                                     NULL };
 
-   // don't merge `method` initialization with function pointers assignment
-   // to prevent relocations (indirect calls) to be generated in the binary
-   method.hashInit   = sha512_224_hashInit;
-   method.hashUpdate = sha512_hashUpdate;
-   method.hashOctStr = sha512_224_hashOctString;
-   method.msgLenRep  = sha512_msgRep;
+    // don't merge `method` initialization with function pointers assignment
+    // to prevent relocations (indirect calls) to be generated in the binary
+    method.hashInit   = sha512_224_hashInit;
+    method.hashOctStr = sha512_224_hashOctString;
+    method.msgLenRep  = sha512_msgRep;
 
-#if (_SHA512_ENABLING_==_FEATURE_TICKTOCK_ || _SHA512_ENABLING_==_FEATURE_ON_)
-   if(IsFeatureEnabled(ippCPUID_AVX2SHA512))
-      method.hashUpdate = sha512_hashUpdate_ni;
+#if (_SHA512_ENABLING_ == _FEATURE_TICKTOCK_ || _SHA512_ENABLING_ == _FEATURE_ON_)
+    if (IsFeatureEnabled(ippCPUID_AVX2SHA512)) {
+        method.hashUpdate = sha512_hashUpdate_ni;
+        return &method;
+    }
 #endif
 
-   return &method;
+    method.hashUpdate = sha512_hashUpdate;
+    return &method;
 }

--- a/sources/ippcp/hash/sha512/pcphashmethod_sha512_256_tt.c
+++ b/sources/ippcp/hash/sha512/pcphashmethod_sha512_256_tt.c
@@ -44,30 +44,30 @@
 //
 *F*/
 
-IPPFUN( const IppsHashMethod*, ippsHashMethod_SHA512_256_TT, (void) )
+IPPFUN(const IppsHashMethod*, ippsHashMethod_SHA512_256_TT, (void))
 {
-   static IppsHashMethod method = {
-      ippHashAlg_SHA512_256,
-      IPP_SHA256_DIGEST_BITSIZE/8,
-      MBS_SHA512,
-      MLR_SHA512,
-      NULL,
-      NULL,
-      NULL,
-      NULL
-   };
+    static IppsHashMethod method = { ippHashAlg_SHA512_256,
+                                     IPP_SHA256_DIGEST_BITSIZE / 8,
+                                     MBS_SHA512,
+                                     MLR_SHA512,
+                                     NULL,
+                                     NULL,
+                                     NULL,
+                                     NULL };
 
-   // don't merge `method` initialization with function pointers assignment
-   // to prevent relocations (indirect calls) to be generated in the binary
-   method.hashInit   = sha512_256_hashInit;
-   method.hashUpdate = sha512_hashUpdate;
-   method.hashOctStr = sha512_256_hashOctString;
-   method.msgLenRep  = sha512_msgRep;
+    // don't merge `method` initialization with function pointers assignment
+    // to prevent relocations (indirect calls) to be generated in the binary
+    method.hashInit   = sha512_256_hashInit;
+    method.hashOctStr = sha512_256_hashOctString;
+    method.msgLenRep  = sha512_msgRep;
 
-#if (_SHA512_ENABLING_==_FEATURE_TICKTOCK_ || _SHA512_ENABLING_==_FEATURE_ON_)
-   if(IsFeatureEnabled(ippCPUID_AVX2SHA512))
-      method.hashUpdate = sha512_hashUpdate_ni;
+#if (_SHA512_ENABLING_ == _FEATURE_TICKTOCK_ || _SHA512_ENABLING_ == _FEATURE_ON_)
+    if (IsFeatureEnabled(ippCPUID_AVX2SHA512)) {
+        method.hashUpdate = sha512_hashUpdate_ni;
+        return &method;
+    }
 #endif
 
-   return &method;
+    method.hashUpdate = sha512_hashUpdate;
+    return &method;
 }

--- a/sources/ippcp/hash/sha512/pcphashmethod_sha512_tt.c
+++ b/sources/ippcp/hash/sha512/pcphashmethod_sha512_tt.c
@@ -44,30 +44,30 @@
 //
 *F*/
 
-IPPFUN( const IppsHashMethod*, ippsHashMethod_SHA512_TT, (void) )
+IPPFUN(const IppsHashMethod*, ippsHashMethod_SHA512_TT, (void))
 {
-   static IppsHashMethod method = {
-      ippHashAlg_SHA512,
-      IPP_SHA512_DIGEST_BITSIZE/8,
-      MBS_SHA512,
-      MLR_SHA512,
-      NULL,
-      NULL,
-      NULL,
-      NULL
-   };
+    static IppsHashMethod method = { ippHashAlg_SHA512,
+                                     IPP_SHA512_DIGEST_BITSIZE / 8,
+                                     MBS_SHA512,
+                                     MLR_SHA512,
+                                     NULL,
+                                     NULL,
+                                     NULL,
+                                     NULL };
 
-   // don't merge `method` initialization with function pointers assignment
-   // to prevent relocations (indirect calls) to be generated in the binary
-   method.hashInit   = sha512_hashInit;
-   method.hashUpdate = sha512_hashUpdate;
-   method.hashOctStr = sha512_hashOctString;
-   method.msgLenRep  = sha512_msgRep;
+    // don't merge `method` initialization with function pointers assignment
+    // to prevent relocations (indirect calls) to be generated in the binary
+    method.hashInit   = sha512_hashInit;
+    method.hashOctStr = sha512_hashOctString;
+    method.msgLenRep  = sha512_msgRep;
 
-#if (_SHA512_ENABLING_==_FEATURE_TICKTOCK_ || _SHA512_ENABLING_==_FEATURE_ON_)
-   if(IsFeatureEnabled(ippCPUID_AVX2SHA512))
-      method.hashUpdate = sha512_hashUpdate_ni;
+#if (_SHA512_ENABLING_ == _FEATURE_TICKTOCK_ || _SHA512_ENABLING_ == _FEATURE_ON_)
+    if (IsFeatureEnabled(ippCPUID_AVX2SHA512)) {
+        method.hashUpdate = sha512_hashUpdate_ni;
+        return &method;
+    }
 #endif
 
-   return &method;
+    method.hashUpdate = sha512_hashUpdate;
+    return &method;
 }

--- a/sources/ippcp/hash/sha512/pcphashmethodset_sha512_224_tt.c
+++ b/sources/ippcp/hash/sha512/pcphashmethodset_sha512_224_tt.c
@@ -44,24 +44,26 @@
 //
 *F*/
 
-IPPFUN( IppStatus, ippsHashMethodSet_SHA512_224_TT, (IppsHashMethod* pMethod) )
+IPPFUN(IppStatus, ippsHashMethodSet_SHA512_224_TT, (IppsHashMethod * pMethod))
 {
-   /* test pointers */
-   IPP_BAD_PTR1_RET(pMethod);
+    /* test pointers */
+    IPP_BAD_PTR1_RET(pMethod);
 
-   pMethod->hashAlgId     = ippHashAlg_SHA512_224;
-   pMethod->hashLen       = IPP_SHA224_DIGEST_BITSIZE/8;
-   pMethod->msgBlkSize    = MBS_SHA512;
-   pMethod->msgLenRepSize = MLR_SHA512;
-   pMethod->hashInit      = sha512_224_hashInit;
-   pMethod->hashUpdate    = sha512_hashUpdate;
-   pMethod->hashOctStr    = sha512_224_hashOctString;
-   pMethod->msgLenRep     = sha512_msgRep;
+    pMethod->hashAlgId     = ippHashAlg_SHA512_224;
+    pMethod->hashLen       = IPP_SHA224_DIGEST_BITSIZE / 8;
+    pMethod->msgBlkSize    = MBS_SHA512;
+    pMethod->msgLenRepSize = MLR_SHA512;
+    pMethod->hashInit      = sha512_224_hashInit;
+    pMethod->hashOctStr    = sha512_224_hashOctString;
+    pMethod->msgLenRep     = sha512_msgRep;
 
-#if (_SHA512_ENABLING_==_FEATURE_TICKTOCK_ || _SHA512_ENABLING_==_FEATURE_ON_)
-   if(IsFeatureEnabled(ippCPUID_AVX2SHA512))
-      pMethod->hashUpdate = sha512_hashUpdate_ni;
+#if (_SHA512_ENABLING_ == _FEATURE_TICKTOCK_ || _SHA512_ENABLING_ == _FEATURE_ON_)
+    if (IsFeatureEnabled(ippCPUID_AVX2SHA512)) {
+        pMethod->hashUpdate = sha512_hashUpdate_ni;
+        return ippStsNoErr;
+    }
 #endif
 
-   return ippStsNoErr;
+    pMethod->hashUpdate = sha512_hashUpdate;
+    return ippStsNoErr;
 }

--- a/sources/ippcp/hash/sha512/pcphashmethodset_sha512_256_tt.c
+++ b/sources/ippcp/hash/sha512/pcphashmethodset_sha512_256_tt.c
@@ -44,24 +44,26 @@
 //
 *F*/
 
-IPPFUN( IppStatus, ippsHashMethodSet_SHA512_256_TT, (IppsHashMethod* pMethod) )
+IPPFUN(IppStatus, ippsHashMethodSet_SHA512_256_TT, (IppsHashMethod * pMethod))
 {
-   /* test pointers */
-   IPP_BAD_PTR1_RET(pMethod);
+    /* test pointers */
+    IPP_BAD_PTR1_RET(pMethod);
 
-   pMethod->hashAlgId     = ippHashAlg_SHA512_256;
-   pMethod->hashLen       = IPP_SHA256_DIGEST_BITSIZE/8;
-   pMethod->msgBlkSize    = MBS_SHA512;
-   pMethod->msgLenRepSize = MLR_SHA512;
-   pMethod->hashInit      = sha512_256_hashInit;
-   pMethod->hashUpdate    = sha512_hashUpdate;
-   pMethod->hashOctStr    = sha512_256_hashOctString;
-   pMethod->msgLenRep     = sha512_msgRep;
+    pMethod->hashAlgId     = ippHashAlg_SHA512_256;
+    pMethod->hashLen       = IPP_SHA256_DIGEST_BITSIZE / 8;
+    pMethod->msgBlkSize    = MBS_SHA512;
+    pMethod->msgLenRepSize = MLR_SHA512;
+    pMethod->hashInit      = sha512_256_hashInit;
+    pMethod->hashOctStr    = sha512_256_hashOctString;
+    pMethod->msgLenRep     = sha512_msgRep;
 
-#if (_SHA512_ENABLING_==_FEATURE_TICKTOCK_ || _SHA512_ENABLING_==_FEATURE_ON_)
-   if(IsFeatureEnabled(ippCPUID_AVX2SHA512))
-      pMethod->hashUpdate = sha512_hashUpdate_ni;
+#if (_SHA512_ENABLING_ == _FEATURE_TICKTOCK_ || _SHA512_ENABLING_ == _FEATURE_ON_)
+    if (IsFeatureEnabled(ippCPUID_AVX2SHA512)) {
+        pMethod->hashUpdate = sha512_hashUpdate_ni;
+        return ippStsNoErr;
+    }
 #endif
 
-   return ippStsNoErr;
+    pMethod->hashUpdate = sha512_hashUpdate;
+    return ippStsNoErr;
 }

--- a/sources/ippcp/hash/sha512/pcphashmethodset_sha512_tt.c
+++ b/sources/ippcp/hash/sha512/pcphashmethodset_sha512_tt.c
@@ -43,23 +43,25 @@
 //
 *F*/
 
-IPPFUN( IppStatus, ippsHashMethodSet_SHA512_TT, (IppsHashMethod* pMethod) )
+IPPFUN(IppStatus, ippsHashMethodSet_SHA512_TT, (IppsHashMethod * pMethod))
 {
-   IPP_BAD_PTR1_RET(pMethod);
+    IPP_BAD_PTR1_RET(pMethod);
 
-   pMethod->hashAlgId     = ippHashAlg_SHA512;
-   pMethod->hashLen       = IPP_SHA512_DIGEST_BITSIZE/8;
-   pMethod->msgBlkSize    = MBS_SHA512;
-   pMethod->msgLenRepSize = MLR_SHA512;
-   pMethod->hashInit      = sha512_hashInit;
-   pMethod->hashUpdate    = sha512_hashUpdate;
-   pMethod->hashOctStr    = sha512_hashOctString;
-   pMethod->msgLenRep     = sha512_msgRep;
+    pMethod->hashAlgId     = ippHashAlg_SHA512;
+    pMethod->hashLen       = IPP_SHA512_DIGEST_BITSIZE / 8;
+    pMethod->msgBlkSize    = MBS_SHA512;
+    pMethod->msgLenRepSize = MLR_SHA512;
+    pMethod->hashInit      = sha512_hashInit;
+    pMethod->hashOctStr    = sha512_hashOctString;
+    pMethod->msgLenRep     = sha512_msgRep;
 
-#if (_SHA512_ENABLING_==_FEATURE_TICKTOCK_ || _SHA512_ENABLING_==_FEATURE_ON_)
-   if(IsFeatureEnabled(ippCPUID_AVX2SHA512))
-      pMethod->hashUpdate = sha512_hashUpdate_ni;
+#if (_SHA512_ENABLING_ == _FEATURE_TICKTOCK_ || _SHA512_ENABLING_ == _FEATURE_ON_)
+    if (IsFeatureEnabled(ippCPUID_AVX2SHA512)) {
+        pMethod->hashUpdate = sha512_hashUpdate_ni;
+        return ippStsNoErr;
+    }
 #endif
 
-   return ippStsNoErr;
+    pMethod->hashUpdate = sha512_hashUpdate;
+    return ippStsNoErr;
 }

--- a/sources/ippcp/hash/sha512/pcphashstatemethodset_sha512_224_tt.c
+++ b/sources/ippcp/hash/sha512/pcphashstatemethodset_sha512_224_tt.c
@@ -44,26 +44,30 @@
 //
 *F*/
 
-IPPFUN( IppStatus, ippsHashStateMethodSet_SHA512_224_TT, (IppsHashState_rmf* pState, IppsHashMethod* pMethod) )
+IPPFUN(IppStatus,
+       ippsHashStateMethodSet_SHA512_224_TT,
+       (IppsHashState_rmf * pState, IppsHashMethod* pMethod))
 {
-   /* test pointers */
-   IPP_BAD_PTR2_RET(pState, pMethod);
+    /* test pointers */
+    IPP_BAD_PTR2_RET(pState, pMethod);
 
-   HASH_METHOD(pState) = pMethod;
+    HASH_METHOD(pState) = pMethod;
 
-   pMethod->hashAlgId     = ippHashAlg_SHA512_224;
-   pMethod->hashLen       = IPP_SHA224_DIGEST_BITSIZE/8;
-   pMethod->msgBlkSize    = MBS_SHA512;
-   pMethod->msgLenRepSize = MLR_SHA512;
-   pMethod->hashInit      = sha512_224_hashInit;
-   pMethod->hashUpdate    = sha512_hashUpdate;
-   pMethod->hashOctStr    = sha512_224_hashOctString;
-   pMethod->msgLenRep     = sha512_msgRep;
+    pMethod->hashAlgId     = ippHashAlg_SHA512_224;
+    pMethod->hashLen       = IPP_SHA224_DIGEST_BITSIZE / 8;
+    pMethod->msgBlkSize    = MBS_SHA512;
+    pMethod->msgLenRepSize = MLR_SHA512;
+    pMethod->hashInit      = sha512_224_hashInit;
+    pMethod->hashOctStr    = sha512_224_hashOctString;
+    pMethod->msgLenRep     = sha512_msgRep;
 
-#if (_SHA512_ENABLING_==_FEATURE_TICKTOCK_ || _SHA512_ENABLING_==_FEATURE_ON_)
-   if(IsFeatureEnabled(ippCPUID_AVX2SHA512))
-      pMethod->hashUpdate = sha512_hashUpdate_ni;
+#if (_SHA512_ENABLING_ == _FEATURE_TICKTOCK_ || _SHA512_ENABLING_ == _FEATURE_ON_)
+    if (IsFeatureEnabled(ippCPUID_AVX2SHA512)) {
+        pMethod->hashUpdate = sha512_hashUpdate_ni;
+        return ippStsNoErr;
+    }
 #endif
 
-   return ippStsNoErr;
+    pMethod->hashUpdate = sha512_hashUpdate;
+    return ippStsNoErr;
 }

--- a/sources/ippcp/hash/sha512/pcphashstatemethodset_sha512_256_tt.c
+++ b/sources/ippcp/hash/sha512/pcphashstatemethodset_sha512_256_tt.c
@@ -44,26 +44,30 @@
 //
 *F*/
 
-IPPFUN( IppStatus, ippsHashStateMethodSet_SHA512_256_TT, (IppsHashState_rmf* pState, IppsHashMethod* pMethod) )
+IPPFUN(IppStatus,
+       ippsHashStateMethodSet_SHA512_256_TT,
+       (IppsHashState_rmf * pState, IppsHashMethod* pMethod))
 {
-   /* test pointers */
-   IPP_BAD_PTR2_RET(pState, pMethod);
+    /* test pointers */
+    IPP_BAD_PTR2_RET(pState, pMethod);
 
-   HASH_METHOD(pState) = pMethod;
+    HASH_METHOD(pState) = pMethod;
 
-   pMethod->hashAlgId     = ippHashAlg_SHA512_256;
-   pMethod->hashLen       = IPP_SHA256_DIGEST_BITSIZE/8;
-   pMethod->msgBlkSize    = MBS_SHA512;
-   pMethod->msgLenRepSize = MLR_SHA512;
-   pMethod->hashInit      = sha512_256_hashInit;
-   pMethod->hashUpdate    = sha512_hashUpdate;
-   pMethod->hashOctStr    = sha512_256_hashOctString;
-   pMethod->msgLenRep     = sha512_msgRep;
+    pMethod->hashAlgId     = ippHashAlg_SHA512_256;
+    pMethod->hashLen       = IPP_SHA256_DIGEST_BITSIZE / 8;
+    pMethod->msgBlkSize    = MBS_SHA512;
+    pMethod->msgLenRepSize = MLR_SHA512;
+    pMethod->hashInit      = sha512_256_hashInit;
+    pMethod->hashOctStr    = sha512_256_hashOctString;
+    pMethod->msgLenRep     = sha512_msgRep;
 
-#if (_SHA512_ENABLING_==_FEATURE_TICKTOCK_ || _SHA512_ENABLING_==_FEATURE_ON_)
-   if(IsFeatureEnabled(ippCPUID_AVX2SHA512))
-      pMethod->hashUpdate = sha512_hashUpdate_ni;
+#if (_SHA512_ENABLING_ == _FEATURE_TICKTOCK_ || _SHA512_ENABLING_ == _FEATURE_ON_)
+    if (IsFeatureEnabled(ippCPUID_AVX2SHA512)) {
+        pMethod->hashUpdate = sha512_hashUpdate_ni;
+        return ippStsNoErr;
+    }
 #endif
 
-   return ippStsNoErr;
+    pMethod->hashUpdate = sha512_hashUpdate;
+    return ippStsNoErr;
 }

--- a/sources/ippcp/hash/sha512/pcphashstatemethodset_sha512_tt.c
+++ b/sources/ippcp/hash/sha512/pcphashstatemethodset_sha512_tt.c
@@ -44,26 +44,30 @@
 //
 *F*/
 
-IPPFUN( IppStatus, ippsHashStateMethodSet_SHA512_TT, (IppsHashState_rmf* pState, IppsHashMethod* pMethod) )
+IPPFUN(IppStatus,
+       ippsHashStateMethodSet_SHA512_TT,
+       (IppsHashState_rmf * pState, IppsHashMethod* pMethod))
 {
-   /* test pointers */
-   IPP_BAD_PTR2_RET(pState, pMethod);
+    /* test pointers */
+    IPP_BAD_PTR2_RET(pState, pMethod);
 
-   HASH_METHOD(pState) = pMethod;
+    HASH_METHOD(pState) = pMethod;
 
-   pMethod->hashAlgId     = ippHashAlg_SHA512;
-   pMethod->hashLen       = IPP_SHA512_DIGEST_BITSIZE/8;
-   pMethod->msgBlkSize    = MBS_SHA512;
-   pMethod->msgLenRepSize = MLR_SHA512;
-   pMethod->hashInit      = sha512_hashInit;
-   pMethod->hashUpdate    = sha512_hashUpdate;
-   pMethod->hashOctStr    = sha512_hashOctString;
-   pMethod->msgLenRep     = sha512_msgRep;
+    pMethod->hashAlgId     = ippHashAlg_SHA512;
+    pMethod->hashLen       = IPP_SHA512_DIGEST_BITSIZE / 8;
+    pMethod->msgBlkSize    = MBS_SHA512;
+    pMethod->msgLenRepSize = MLR_SHA512;
+    pMethod->hashInit      = sha512_hashInit;
+    pMethod->hashOctStr    = sha512_hashOctString;
+    pMethod->msgLenRep     = sha512_msgRep;
 
-#if (_SHA512_ENABLING_==_FEATURE_TICKTOCK_ || _SHA512_ENABLING_==_FEATURE_ON_)
-   if(IsFeatureEnabled(ippCPUID_AVX2SHA512))
-      pMethod->hashUpdate = sha512_hashUpdate_ni;
+#if (_SHA512_ENABLING_ == _FEATURE_TICKTOCK_ || _SHA512_ENABLING_ == _FEATURE_ON_)
+    if (IsFeatureEnabled(ippCPUID_AVX2SHA512)) {
+        pMethod->hashUpdate = sha512_hashUpdate_ni;
+        return ippStsNoErr;
+    }
 #endif
 
-   return ippStsNoErr;
+    pMethod->hashUpdate = sha512_hashUpdate;
+    return ippStsNoErr;
 }


### PR DESCRIPTION
This is done to avoid setting the variable twice, because in a multithreaded environment this destroys memory caches. Note that to make the code cleaner I used an early return in the special `sha256_ni_hashUpdate` case.

Compilation using the Intel® oneAPI DPC++/C++ compiler succeeded.
Code formatted according to the [.clang-format](.clang-format) rules.
Added a note in change log and incremented the version.

Fixes intel/linux-sgx#1073
