### PR TITLE
[Doc] fix typo in mbx_nistp521

### DIFF
--- a/doc/source/mbx_nistp256-384-521_ecdsa_sign_setup.rst
+++ b/doc/source/mbx_nistp256-384-521_ecdsa_sign_setup.rst
@@ -46,13 +46,13 @@ Include Files
 -------------
 
 
-``crypto_mb/ec_nistp256.h```
+``crypto_mb/ec_nistp256.h``
 
 
 ``crypto_mb/ec_nistp384.h``
 
 
-``crypto_mb/ec_nistp512.h``
+``crypto_mb/ec_nistp521.h``
 
 
 Parameters

--- a/doc/source/mbx_nistp256-384-521_ecdsa_verify.rst
+++ b/doc/source/mbx_nistp256-384-521_ecdsa_verify.rst
@@ -59,7 +59,7 @@ Include Files
 ``crypto_mb/ec_nistp384.h``
 
 
-``crypto_mb/ec_nistp512.h``
+``crypto_mb/ec_nistp521.h``
 
 
 Parameters


### PR DESCRIPTION
It's P-521 (prime).
Also an extra backtick.